### PR TITLE
Kudos−06 マルチテナント機能を設定 #6

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,8 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
-  # Devise認証を必須にする
   before_action :authenticate_user!
+  before_action :set_current_organization
 
   #Deviseの新規登録、アカウント更新時の設定
   before_action :configure_permitted_parameters, if: :devise_controller?
@@ -13,5 +13,13 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name])
+  end
+
+  # ユーザーの組織を設定
+  def set_current_organization
+    if user_signed_in?
+      Current.user = current_user
+      Current.organization = current_user.organization
+    end
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,10 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # マルチテナント用のメソッド
+  def self.acts_as_tenant
+    default_scope { where(organization_id: Current.organization_id) if Current.organization_id.present? }
+    belongs_to :organization
+    validates :organization_id, presence: true
+  end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,9 @@
+class Current < ActiveSupport::CurrentAttributes
+    attribute :organization
+    attribute :user
+
+    # organization_idを取得
+    def organization_id
+        organization&.id
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  acts_as_tenant
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -8,4 +9,9 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, presence: true, length: { maximum: 50 }
   validates :organization_id, presence: true
+
+  # 同じ組織かどうかを判定
+  def same_organization?(other_user)
+    self.organization_id == other_user.organization_id
+  end
 end


### PR DESCRIPTION
  概要

  組織ごとのデータ分離機能を実装しました。ユーザーは自分の組織のデータのみアクセス可能になります。

  実装内容

  - Currentクラスを作成してリクエスト単位で組織情報を保持
  - ApplicationRecordにacts_as_tenantメソッドとdefault_scope追加
  - マルチテナント機能でデータ自動分離
  - ApplicationControllerで組織の自動設定

  変更ファイル

  - app/models/current.rb - 新規作成（Current属性管理）
  - app/models/application_record.rb - マルチテナント機能追加
  - app/controllers/application_controller.rb - 組織自動設定
  - app/models/user.rb - acts_as_tenant適用

  動作確認

  - rails consoleでマルチテナント機能動作確認済み
  - 組織別データ分離確認済み（SQLクエリでWHERE句自動追加）
  - 異なる組織間でのデータアクセス制御確認済み

  テスト結果

組織1: 3ユーザー、組織2: 1ユーザーで分離動作確認
  Current.organization = org1 # WHERE organization_id = 1
  Current.organization = org2 # WHERE organization_id = 2