### PR TITLE
Kudos-07 組織階層モデル作成 #7

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,0 +1,12 @@
+class Department < ApplicationRecord
+  acts_as_tenant
+
+  belongs_to :office, optional: true
+  belongs_to :manager, class_name: 'User', optional: true
+
+  # 部署が削除されたら、その部署に属する課を削除、ユーザーの所属をnullに
+  has_many :sections, dependent: :destroy
+  has_many :users, dependent: :nullify
+
+  validates :name, presence: true, length: { maximum: 100 }
+end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,0 +1,13 @@
+class Office < ApplicationRecord
+  acts_as_tenant
+
+  # 事業所が削除されたら、その事業所に属する部署を削除、ユーザーの所属をnullに
+  has_many :departments, dependent: :destroy
+  has_many :users, dependent: :nullify
+
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :is_headquarters, inclusion: { in: [true, false] }
+
+  scope :headquarters, -> { where(is_headquarters: true) }
+  scope :branches, -> { where(is_headquarters: false) }
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,11 @@
 class Organization < ApplicationRecord
-    validates :name, presence: true, length: { maximum: 50 }
+  validates :name, presence: true, length: { maximum: 50 }
 
-    has_many :users
+  # ユーザーがいる場合は削除できない
+  has_many :users, dependent: :restrict_with_exception
+
+  # 組織が削除されたら、その組織に属する全てのデータも削除
+  has_many :offices, dependent: :destroy
+  has_many :departments, dependent: :destroy
+  has_many :sections, dependent: :destroy
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,0 +1,11 @@
+class Section < ApplicationRecord
+  acts_as_tenant
+
+  belongs_to :department, optional: true
+  belongs_to :manager, class_name: 'User', optional: true
+
+  # 課が削除されたら、その課に属するユーザーの所属をnullに
+  has_many :users, dependent: :nullify
+
+  validates :name, presence: true, length: { maximum: 100 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,12 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   belongs_to :organization
+  belongs_to :office, optional: true
+  belongs_to :department, optional: true
+  belongs_to :section, optional: true
+
+  has_many :managed_departments, class_name: "Department", foreign_key: "manager_id"
+  has_many :managed_sections, class_name: "Section", foreign_key: "manager_id"
 
   validates :first_name, :last_name, presence: true, length: { maximum: 50 }
   validates :organization_id, presence: true
@@ -13,5 +19,9 @@ class User < ApplicationRecord
   # 同じ組織かどうかを判定
   def same_organization?(other_user)
     self.organization_id == other_user.organization_id
+  end
+
+  def full_name
+    "#{first_name} #{last_name}"
   end
 end

--- a/db/migrate/20250928030246_create_offices.rb
+++ b/db/migrate/20250928030246_create_offices.rb
@@ -1,0 +1,13 @@
+class CreateOffices < ActiveRecord::Migration[7.2]
+  def change
+    create_table :offices do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.string :name, limit: 100, null: false
+      t.string :address
+      t.boolean :is_headquarters,default: false
+
+      t.timestamps
+    end
+    add_index :offices, [:organization_id, :name]
+  end
+end

--- a/db/migrate/20250928030253_create_departments.rb
+++ b/db/migrate/20250928030253_create_departments.rb
@@ -1,0 +1,13 @@
+class CreateDepartments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :departments do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.references :office, null: true, foreign_key: true
+      t.string :name, limit: 100, null: false
+      t.references :manager, null: true, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+    add_index :departments, [:organization_id, :name]
+  end
+end

--- a/db/migrate/20250928030301_create_sections.rb
+++ b/db/migrate/20250928030301_create_sections.rb
@@ -1,0 +1,13 @@
+class CreateSections < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sections do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.references :department, null: true, foreign_key: true
+      t.string :name, limit: 100, null: false
+      t.references :manager, null: true, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+    add_index :sections, [:organization_id, :name]
+  end
+end

--- a/db/migrate/20250928040719_add_organization_hierarchy_to_users.rb
+++ b/db/migrate/20250928040719_add_organization_hierarchy_to_users.rb
@@ -1,0 +1,7 @@
+class AddOrganizationHierarchyToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :users, :office, null: true, foreign_key: true
+    add_reference :users, :department, null: true, foreign_key: true
+    add_reference :users, :section, null: true, foreign_key: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,41 +1,187 @@
-# テストユーザー作成
-puts "Creating test users..."
+# テストユーザーと組織階層作成
+puts "Creating test organizations and hierarchy..."
 
 # 組織データ
-company1 = Organization.create!(name: "株式会社テスト1")
-company2 = Organization.create!(name: "株式会社テスト2")
+company1 = Organization.find_or_create_by!(name: "株式会社テスト1")
+company2 = Organization.find_or_create_by!(name: "株式会社テスト2")
 
-# 管理者ユーザー
+# === 組織1の階層構造 ===
+puts "Creating hierarchy for #{company1.name}..."
+
+# 支社作成
+tokyo_office = Office.find_or_create_by!(
+  organization: company1,
+  name: "東京本社",
+  is_headquarters: true,
+  address: "東京都千代田区"
+)
+
+osaka_office = Office.find_or_create_by!(
+  organization: company1,
+  name: "大阪支社",
+  is_headquarters: false,
+  address: "大阪府大阪市"
+)
+
+# 部署作成（東京本社）
+sales_dept = Department.find_or_create_by!(
+  organization: company1,
+  office: tokyo_office,
+  name: "営業部"
+)
+
+dev_dept = Department.find_or_create_by!(
+  organization: company1,
+  office: tokyo_office,
+  name: "開発部"
+)
+
+hr_dept = Department.find_or_create_by!(
+  organization: company1,
+  office: tokyo_office,
+  name: "人事部"
+)
+
+# 部署作成（大阪支社）
+sales_osaka_dept = Department.find_or_create_by!(
+  organization: company1,
+  office: osaka_office,
+  name: "営業部"
+)
+
+# 課作成（営業部）
+first_sales_section = Section.find_or_create_by!(
+  organization: company1,
+  department: sales_dept,
+  name: "第一営業課"
+)
+
+second_sales_section = Section.find_or_create_by!(
+  organization: company1,
+  department: sales_dept,
+  name: "第二営業課"
+)
+
+# 課作成（開発部）
+frontend_section = Section.find_or_create_by!(
+  organization: company1,
+  department: dev_dept,
+  name: "フロントエンド課"
+)
+
+backend_section = Section.find_or_create_by!(
+  organization: company1,
+  department: dev_dept,
+  name: "バックエンド課"
+)
+
+# === 組織2の階層構造（シンプル） ===
+puts "Creating hierarchy for #{company2.name}..."
+
+# 本社のみ
+main_office = Office.find_or_create_by!(
+  organization: company2,
+  name: "本社",
+  is_headquarters: true,
+  address: "神奈川県横浜市"
+)
+
+# 部署1つ
+general_dept = Department.find_or_create_by!(
+  organization: company2,
+  office: main_office,
+  name: "総務部"
+)
+
+# === ユーザー作成 ===
+puts "Creating test users..."
+
+# 管理者ユーザー（組織1）
 admin = User.find_or_create_by(email: "admin@kudos.local") do |user|
   user.password = "password"
   user.password_confirmation = "password"
   user.first_name = "管理"
   user.last_name = "太郎"
   user.organization = company1
+  user.office = tokyo_office
+  user.department = hr_dept
 end
 
-# 一般ユーザー1
+# 営業部長（組織1）
+sales_manager = User.find_or_create_by(email: "sales-manager@kudos.local") do |user|
+  user.password = "password"
+  user.password_confirmation = "password"
+  user.first_name = "営業"
+  user.last_name = "部長"
+  user.organization = company1
+  user.office = tokyo_office
+  user.department = sales_dept
+end
+
+# 営業課長（組織1）
+sales_section_manager = User.find_or_create_by(email: "sales-section@kudos.local") do |user|
+  user.password = "password"
+  user.password_confirmation = "password"
+  user.first_name = "第一"
+  user.last_name = "課長"
+  user.organization = company1
+  user.office = tokyo_office
+  user.department = sales_dept
+  user.section = first_sales_section
+end
+
+# 開発者（組織1）
+developer = User.find_or_create_by(email: "dev@kudos.local") do |user|
+  user.password = "password"
+  user.password_confirmation = "password"
+  user.first_name = "開発"
+  user.last_name = "太郎"
+  user.organization = company1
+  user.office = tokyo_office
+  user.department = dev_dept
+  user.section = frontend_section
+end
+
+# 一般ユーザー1（組織1）
 user1 = User.find_or_create_by(email: "user1@kudos.local") do |user|
   user.password = "password"
   user.password_confirmation = "password"
   user.first_name = "田中"
   user.last_name = "次郎"
   user.organization = company1
+  user.office = tokyo_office
+  user.department = sales_dept
+  user.section = second_sales_section
 end
 
-# 一般ユーザー2
+# 一般ユーザー2（組織2）
 user2 = User.find_or_create_by(email: "user2@kudos.local") do |user|
   user.password = "password"
   user.password_confirmation = "password"
   user.first_name = "佐藤"
   user.last_name = "花子"
   user.organization = company2
+  user.office = main_office
+  user.department = general_dept
 end
 
-puts "Successfully Created #{User.count} users"
+# === 管理職の設定 ===
+sales_dept.update!(manager: sales_manager)
+first_sales_section.update!(manager: sales_section_manager)
+
+puts ""
+puts "=== 作成完了 ==="
+puts "組織: #{Organization.count}社"
+puts "支社: #{Office.count}拠点"
+puts "部署: #{Department.count}部署"
+puts "課: #{Section.count}課"
+puts "ユーザー: #{User.count}名"
 puts ""
 puts "=== Test Accounts ==="
 puts "管理者: admin@kudos.local / password"
+puts "営業部長: sales-manager@kudos.local / password"
+puts "営業課長: sales-section@kudos.local / password"
+puts "開発者: dev@kudos.local / password"
 puts "ユーザー1: user1@kudos.local / password"
 puts "ユーザー2: user2@kudos.local / password"
 puts "===================="


### PR DESCRIPTION
  実装内容

  - Office（支社/拠点）: 本社・支社の管理、本社フラグ付き
  - Department（部署）: 各支社の部署管理、部長設定可能
  - Section（課/チーム）: 各部署の課管理、課長設定可能
  - 柔軟な階層: 階層スキップ可能（部署直属、課なし運用）
  - マルチテナント: 全モデルで組織別データ分離

  変更ファイル

  - app/models/office.rb - 新規作成
  - app/models/department.rb - 新規作成
  - app/models/section.rb - 新規作成
  - app/models/organization.rb - 階層関連付け追加
  - app/models/user.rb - 組織階層所属、管理職関連追加
  - db/migrate/ - 3つのテーブル作成、Userテーブル拡張
  - db/seeds.rb - 階層構造サンプルデータ追加

  動作確認

  - 階層表示: 東京本社・大阪支社の複層構造確認済み
  - 管理職機能: 営業部長・営業課長の設定確認済み
  - マルチテナント: 組織別データ分離動作確認済み
  - 柔軟性: optional関連による階層スキップ確認済み