### PR TITLE
Issue #9: ユーザー一覧・詳細画面の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ tmp/postgres_backup/
 
 # 本番設定
 /config/settings.local.yml
+
+# デザインファイル
+/design/
+design/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,47 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_user, only: [:show]
+
+  def index
+    @search_term = params[:q]
+
+    # 統計用の変数
+    @total_active_users = Current.organization.users.active.count
+    @current_month_kudos = 1247
+    @active_user_count = Current.organization.users.active.count
+    @new_users_this_month = 12
+
+    # 基本的なユーザー取得
+    users_scope = Current.organization.users.active.includes(:office, :department, :section)
+
+    # データベースから取得してソート
+    all_users = users_scope.order(:office_id, :department_id, :section_id, :last_name)
+
+    # 検索処理
+    if @search_term.present?
+      @users = all_users.select { |user| user.full_name.include?(@search_term) }
+    end
+
+    # 組織階層表示用
+    @offices = Current.organization.offices.includes(
+      departments: { sections: :users }
+    ).order(is_headquarters: :desc, name: :asc)
+  end
+
+  def show
+  end
+
+  def search
+    redirect_to users_path(q: params[:q])
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+    # 異なる組織のユーザーは見れない
+    unless @user.same_organization?(current_user)
+      redirect_to users_path, alert: "アクセス権限がありません"
+    end
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "icon"]
+
+  connect() {
+    // 初期状態は閉じた状態にする
+    this.isExpanded = false
+    this.contentTarget.style.maxHeight = "0px"
+  }
+
+  toggle() {
+    if (this.isExpanded) {
+      // 閉じる
+      this.contentTarget.style.maxHeight = "0px"
+      this.iconTarget.style.transform = "rotate(-90deg)"
+      this.isExpanded = false
+    } else {
+      // 開く
+      this.contentTarget.style.maxHeight = "9999px"
+      this.iconTarget.style.transform = "rotate(0deg)"
+      this.isExpanded = true
+    }
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
   end
 
   def full_name
-    "#{first_name} #{last_name}"
+    "#{last_name} #{first_name}"
   end
 
   # 勤続年数を計算

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,9 +18,17 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <main class="container mx-auto mt-28 px-5 flex">
-      <%= yield %>
-    </main>
+  <body class="bg-gray-50">
+    <div class="flex min-h-screen">
+      <!-- サイドバー -->
+      <%= render 'shared/sidebar' %>
+
+      <!-- メインコンテンツ -->
+      <main class="flex-1 overflow-auto">
+        <div class="px-8 py-6">
+          <%= yield %>
+        </div>
+      </main>
+    </div>
   </body>
 </html>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,0 +1,82 @@
+<aside class="w-52 bg-white border-r border-gray-200">
+  <div class="flex flex-col h-full">
+    <!-- ロゴ・ヘッダー -->
+    <div class="px-6 py-4 border-b border-gray-200">
+      <%= link_to root_path do %>
+        <h1 class="text-lg font-bold text-gray-900"><%= t('kudos.application_name') %></h1>
+      <% end %>
+    </div>
+
+    <!-- ナビゲーションメニュー -->
+    <nav class="flex-1 py-4">
+      <div class="px-4 mb-6">
+        <p class="text-xs font-medium text-gray-500 mb-2">個人</p>
+
+        <%= link_to root_path, class: "block px-3 py-2 text-sm #{current_page?(root_path) ? 'bg-gray-100 text-gray-900 font-medium' : 'text-gray-700 hover:bg-gray-50'} rounded-md mb-1" do %>
+          ダッシュボード
+        <% end %>
+
+        <button class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md mb-1">
+          Kudosを送る
+        </button>
+
+        <div class="flex items-center justify-between px-3 py-2 text-sm text-gray-700 mb-1">
+          <span>受信箱</span>
+        </div>
+
+        <button class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md mb-1">
+          送信済み
+        </button>
+
+        <button class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md mb-1">
+          個人アクティビティ
+        </button>
+
+        <div class="flex items-center justify-between px-3 py-2 text-sm text-gray-700 mb-1">
+          <span>個人分析</span>
+          <span class="bg-blue-600 text-white text-xs rounded px-2 py-0.5">Pro</span>
+        </div>
+
+        <div class="flex items-center justify-between px-3 py-2 text-sm text-gray-700 mb-1">
+          <span>つながりマップ</span>
+          <span class="bg-blue-600 text-white text-xs rounded px-2 py-0.5">Pro</span>
+        </div>
+
+        <button class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md mb-1">
+          設定
+        </button>
+      </div>
+
+      <div class="px-4">
+        <p class="text-xs font-medium text-gray-500 mb-2">管理者</p>
+
+        <button class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md mb-1">
+          統計
+        </button>
+
+        <div class="flex items-center justify-between px-3 py-2 text-sm text-gray-700 mb-1">
+          <span>強み分析</span>
+          <span class="bg-blue-600 text-white text-xs rounded px-2 py-0.5">Pro</span>
+        </div>
+
+        <div class="flex items-center justify-between px-3 py-2 text-sm text-gray-700 mb-1">
+          <span>チーム分析</span>
+          <span class="bg-blue-600 text-white text-xs rounded px-2 py-0.5">Pro</span>
+        </div>
+
+        <div class="flex items-center justify-between px-3 py-2 text-sm text-gray-700 mb-1">
+          <span>つながりマップ</span>
+          <span class="bg-blue-600 text-white text-xs rounded px-2 py-0.5">Pro</span>
+        </div>
+
+        <%= link_to users_path, class: "block px-3 py-2 text-sm #{controller_name == 'users' ? 'bg-gray-100 text-gray-900 font-medium' : 'text-gray-700 hover:bg-gray-50'} rounded-md mb-1" do %>
+          ユーザー管理
+        <% end %>
+
+        <button class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded-md mb-1">
+          設定
+        </button>
+      </div>
+    </nav>
+  </div>
+</aside>

--- a/app/views/users/_organization_tree.html.erb
+++ b/app/views/users/_organization_tree.html.erb
@@ -1,0 +1,57 @@
+<div class="bg-white rounded-lg border border-gray-200">
+  <% offices.each do |office| %>
+    <% office_icon = '<svg class="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path></svg>'.html_safe %>
+    <%= render layout: 'toggle_section', locals: {
+        section_class: "border-b border-gray-200 last:border-b-0",
+        header_class: "p-4",
+        icon_class: "w-4 h-4",
+        icon_svg: office_icon,
+        level: "3",
+        title_class: "text-lg font-bold text-gray-900",
+        title: office.name,
+        count_class: "text-md font-medium text-gray-700",
+        count: office.users.count,
+        content_class: ""
+    } do %>
+      <div class="px-4 pb-4">
+        <p class="text-sm text-gray-500 mb-4"><%= office.address %> • <%= office.users.count %>人 • <%= office.departments.count %>部署</p>
+        <%= render 'users_grid', users: office.users.where(department: nil), extra_class: 'mb-6' %>
+
+        <% office.departments.each do |dept| %>
+          <%= render layout: 'toggle_section', locals: {
+              section_class: "mb-6",
+              header_class: "py-2 mb-3",
+              icon_class: "w-4 h-4",
+              level: "4",
+              title_class: "text-lg font-semibold text-gray-900",
+              title: dept.name,
+              count_class: "text-sm font-medium text-gray-600",
+              count: dept.users.count,
+              content_class: ""
+          } do %>
+            <div class="ml-6">
+              <p class="text-xs text-gray-500 mb-4">部長: <%= dept.manager&.full_name || "未設定" %> • <%= dept.sections.count %>課</p>
+              <%= render 'users_grid', users: dept.users.where(section: nil) %>
+
+              <% dept.sections.each do |section| %>
+                <%= render layout: 'toggle_section', locals: {
+                    section_class: "mb-4",
+                    header_class: "py-2",
+                    icon_class: "w-3 h-3",
+                    level: "5",
+                    title_class: "text-sm font-semibold text-gray-800",
+                    title: section.name,
+                    count_class: "text-xs font-medium text-gray-600",
+                    count: section.users.count,
+                    content_class: "ml-4"
+                } do %>
+                  <%= render 'users_grid', users: section.users %>
+                <% end %>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/users/_stat_card.html.erb
+++ b/app/views/users/_stat_card.html.erb
@@ -1,0 +1,7 @@
+<div class="bg-white p-4 rounded-lg border border-gray-200">
+  <p class="text-sm text-gray-600"><%= label %></p>
+  <p class="text-2xl font-bold text-gray-900 mt-1"><%= value %></p>
+  <% if defined?(extra) && extra %>
+    <p class="text-xs <%= defined?(extra_class) ? extra_class : 'text-gray-500' %> mt-1"><%= extra %></p>
+  <% end %>
+</div>

--- a/app/views/users/_toggle_section.html.erb
+++ b/app/views/users/_toggle_section.html.erb
@@ -1,0 +1,20 @@
+<div class="<%= section_class %>" data-controller="toggle">
+  <div class="flex items-center justify-between cursor-pointer <%= header_class %>" data-action="click->toggle#toggle">
+    <div class="flex items-center gap-2">
+      <button class="text-gray-400">
+        <svg data-toggle-target="icon" class="<%= icon_class %> transform transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="transform: rotate(-90deg);">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+        </svg>
+      </button>
+      <% if defined?(icon_svg) && icon_svg %>
+        <%= icon_svg %>
+      <% end %>
+      <h<%= level %> class="<%= title_class %>"><%= title %></h<%= level %>>
+      <span class="<%= count_class %>"><%= count %>人</span>
+    </div>
+  </div>
+
+  <div data-toggle-target="content" class="overflow-hidden transition-all duration-300 <%= content_class || '' %>">
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/users/_user_card.html.erb
+++ b/app/views/users/_user_card.html.erb
@@ -1,0 +1,13 @@
+<%= link_to user_path(user), class: "block bg-gray-50 border border-gray-200 rounded-lg p-3 hover:bg-gray-100 transition" do %>
+  <div class="flex items-center gap-2">
+    <div class="w-8 h-8 rounded-full bg-gray-400 flex items-center justify-center text-white font-bold text-sm">
+      <%= user.last_name.first %>
+    </div>
+    <div class="flex-1">
+      <p class="text-sm font-medium text-gray-900"><%= user.full_name %></p>
+      <p class="text-xs text-gray-600"><%= user.position || "一般" %></p>
+      <p class="text-xs text-gray-500"><%= user.email %></p>
+      <p class="text-xs text-gray-500">入社: <%= user.hire_date&.strftime("%Y-%m-%d") || "未設定" %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/_users_grid.html.erb
+++ b/app/views/users/_users_grid.html.erb
@@ -1,0 +1,7 @@
+<% if users.any? %>
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 <%= local_assigns[:extra_class] || 'mb-4' %>">
+    <% users.each do |user| %>
+      <%= render 'user_card', user: user %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,34 @@
+<h1 class="text-2xl font-bold text-gray-900 mb-8">ユーザー管理</h1>
+
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+  <%= render 'stat_card', label: '総従業員数', value: @total_active_users %>
+  <%= render 'stat_card', label: '今月のKudos', value: @current_month_kudos %>
+  <%= render 'stat_card', label: 'アクティブユーザー', value: @active_user_count, extra: "#{(@active_user_count * 100 / @total_active_users.to_f).round}% of total" %>
+  <%= render 'stat_card', label: '今月の新規登録', value: @new_users_this_month %>
+</div>
+
+<%= form_with url: users_path, method: :get, local: true, class: "relative flex-1 max-w-md mb-6" do |f| %>
+  <div class="relative">
+    <svg class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+    </svg>
+    <%= f.text_field :q, placeholder: "名前を検索",
+        class: "pl-10 pr-3 py-2 border border-gray-300 rounded-lg w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+        value: @search_term %>
+  </div>
+<% end %>
+
+<% if @search_term.present? %>
+  <h3 class="text-lg font-semibold mb-4">検索結果: "<%= @search_term %>"</h3>
+  <% if @users.any? %>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-8">
+      <% @users.each do |user| %>
+        <%= render 'user_card', user: user %>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="text-gray-500 mb-8">該当するユーザーが見つかりませんでした。</p>
+  <% end %>
+<% end %>
+
+<%= render 'organization_tree', offices: @offices %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,112 @@
+<div>
+    <!-- ナビゲーション -->
+    <nav class="mb-6">
+      <%= link_to users_path, class: "inline-flex items-center text-blue-600 hover:text-blue-800 transition" do %>
+        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+        </svg>
+        ユーザー管理へ
+      <% end %>
+    </nav>
+
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-gray-900">ユーザー詳細</h1>
+    </div>
+
+    <!-- プロフィールヘッダー -->
+    <div class="bg-white rounded-lg shadow-sm overflow-hidden mb-6">
+      <div class="bg-blue-600 px-8 py-16">
+        <div class="flex items-center gap-6">
+          <div class="w-24 h-24 rounded-full bg-white flex items-center justify-center text-4xl font-bold text-gray-700">
+            <%= @user.last_name.first %>
+          </div>
+          <div class="text-white">
+            <h1 class="text-3xl font-bold"><%= @user.full_name %></h1>
+            <p class="text-xl opacity-90 mt-2"><%= @user.position || "一般社員" %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <!-- メインコンテンツ -->
+      <div class="lg:col-span-2 space-y-6">
+        <!-- 基本情報 -->
+        <div class="bg-white rounded-lg shadow-sm p-6">
+          <h2 class="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+            </svg>
+            基本情報
+          </h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <dt class="text-sm font-medium text-gray-500 mb-1">従業員ID</dt>
+              <dd class="text-lg text-gray-900"><%= @user.employee_id || "未設定" %></dd>
+            </div>
+            <div>
+              <dt class="text-sm font-medium text-gray-500 mb-1">メールアドレス</dt>
+              <dd class="text-lg text-gray-900"><%= @user.email %></dd>
+            </div>
+            <div>
+              <dt class="text-sm font-medium text-gray-500 mb-1">入社日</dt>
+              <dd class="text-lg text-gray-900">
+                <%= @user.hire_date&.strftime("%Y年%m月%d日") || "未設定" %>
+              </dd>
+            </div>
+            <div>
+              <dt class="text-sm font-medium text-gray-500 mb-1">勤続年数</dt>
+              <dd class="text-lg text-gray-900">
+                <%= @user.hire_date ? @user.display_years_of_service : "未設定" %>
+              </dd>
+            </div>
+            <div>
+              <dt class="text-sm font-medium text-gray-500 mb-1">所属</dt>
+              <dd class="text-lg text-gray-900">
+                <%= @user.office.name if @user.office.present? %>
+                <%= @user.department.name if @user.department.present? %>
+                <%= @user.section.name if @user.section.present? %>
+              </dd>
+            </div>
+          </div>
+        </div>
+
+        <!-- 自己紹介 -->
+        <% if @user.bio.present? %>
+          <div class="bg-white rounded-lg shadow-sm p-6">
+            <h2 class="text-xl font-semibold text-gray-900 mb-4 flex items-center gap-2">
+              <svg class="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"></path>
+              </svg>
+              自己紹介
+            </h2>
+            <div class="prose max-w-none">
+              <p class="text-gray-700 leading-relaxed"><%= simple_format(@user.bio) %></p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- サイドバー -->
+      <div class="space-y-6">
+        <!-- 統計情報 -->
+        <div class="bg-white rounded-lg shadow-sm p-6">
+          <h3 class="text-lg font-semibold text-gray-900 mb-4">統計情報</h3>
+          <div class="space-y-4">
+            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+              <span class="text-sm font-medium text-gray-600">受け取ったKudos</span>
+              <span class="text-2xl font-bold text-purple-600">-</span>
+            </div>
+            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+              <span class="text-sm font-medium text-gray-600">送ったKudos</span>
+              <span class="text-2xl font-bold text-purple-600">-</span>
+            </div>
+            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+              <span class="text-sm font-medium text-gray-600">評価スコア</span>
+              <span class="text-2xl font-bold text-purple-600">-</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,13 @@ Rails.application.routes.draw do
 
   root "dashboard#index"
 
+  # ユーザー関連のルート
+  resources :users, only: [:index, :show] do
+    collection do
+      get :search
+    end
+  end
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION

  ユーザー一覧画面 (/users)

  - 統計ダッシュボード: 総従業員数、今月のKudos、アクティブユーザー、新規登録を表示
  - 組織階層ビュー: 事業所 → 部署 → 課の3階層で組織構造を可視化
  - 折りたたみ機能: Stimulus.jsによるインタラクティブな階層表示（初期状態は閉じた状態）
  - 検索機能
  - レスポンシブグリッド: ユーザーカードを1/2/4列で自動調整

  ユーザー詳細画面 (/users/:id)

  - プロフィールヘッダーと基本情報表示
  - 組織情報（所属事業所・部署・課）の表示
  - マルチテナント対応（同一組織のユーザーのみ閲覧可能）